### PR TITLE
Fixed broken link to templates guide

### DIFF
--- a/publisher/reference/shortcodes.mdx
+++ b/publisher/reference/shortcodes.mdx
@@ -81,7 +81,7 @@ Lists all podcast contributors and shows related episodes.
 
 - `[podlove-template template="Template Title"]` renders a template.
 
-All custom shortcode parameters will be accessible in the template. Example: `[podlove-template template="..." customvariable="foo"]`. Please read the [Understanding Templates](/podlove-publisher/guides/understanding-templates/) for more details.
+All custom shortcode parameters will be accessible in the template. Example: `[podlove-template template="..." customvariable="foo"]`. Please read the [Templates guide](/podlove-publisher/guides/templates/) for more details.
 
 ##### Parameters
 


### PR DESCRIPTION
The page at https://docs.podlove.org/podlove-publisher/reference/shortcodes/ links to https://docs.podlove.org/podlove-publisher/guides/understanding-templates/ 

If you *click* the link, it says "Page Not Found". 

However, if you go to the URL directly in your browser, it redirects to the correct page at https://docs.podlove.org/podlove-publisher/guides/templates/

I don't know how to fix the redirecting feature, so I just fixed the link instead.

I made the same change over here: https://github.com/podlove/podlove-publisher/pull/1457