### PR TITLE
Fix links and description. And added an example.

### DIFF
--- a/publisher/api.json
+++ b/publisher/api.json
@@ -6954,7 +6954,7 @@
       "AssetId": {
         "name": "asset_id",
         "in": "path",
-        "description": "Unique identifier for the asset.",
+        "description": "Unique identifier for the asset. Each asset in an episode's set of assets has an ID starting from 1 (e.g., the first asset has asset_id=1, the second asset has asset_id=2, and so on).",
         "required": true,
         "schema": {
           "type": "string"

--- a/publisher/guides/templates.mdx
+++ b/publisher/guides/templates.mdx
@@ -133,6 +133,24 @@ To use them in another template, you need to import the macros before using them
 {% endraw %}
 ```
 
+### Filters
+
+Twig filters can be used to filter the list of episodes. For example, this filter selects only the episodes from the year 2024:
+
+```handlebars
+{% set filtered_episodes = podcast.episodes|filter(episode => episode.publicationDate.format('Y') == "2024") %}
+
+<ul>
+{% for episode in filtered_episodes %}
+  <li>
+    <a href="{{ episode.url }}">
+      {{ episode.title }}
+    </a> — {{ episode.subtitle }}
+  </li>
+{% endfor %}
+</ul>
+```
+
 ## Creating PHP Templates — For Theme Developers
 
 _Available from Podlove Publisher version 2.3_

--- a/publisher/guides/templates.mdx
+++ b/publisher/guides/templates.mdx
@@ -254,7 +254,7 @@ echo get_podcast()->title();
 ?>
 ```
 
-[1]: http://twig.sensiolabs.org/
-[2]: http://twig.sensiolabs.org/doc/templates.html
+[1]: https://twig.symfony.com/
+[2]: https://twig.symfony.com/doc/3.x/templates.html
 [3]: /podlove-publisher/reference/templates/template-tags/podcast
-[4]: http://twig.sensiolabs.org/doc/tags/macro.html
+[4]: https://twig.symfony.com/doc/3.x/tags/macro.html


### PR DESCRIPTION
I made 3 minor fixes to the documentation:

1. Clarified description of `asset_id` in the API docs because it was vague. After failing to use `episodes/{id}/media/{asset_id}/enable` in my code I dug deeper and realized that asset_id is not a globally-unique ID (such as primary key `id`). Instead, the asset_id refers to `episode_asset_id` column of table `wp_podlove_mediafile` (and not the `id` column). 
2. Official Twig homepage has changed: `twig.sensiolabs.org` is now `twig.symfony.com`. 
3. I added a twig example of filtering to select episodes from a given year because it took me a while to figure this out, and I thought it could help others since selecting by year feels like a common use case.

By the way, I noticed the existing twig examples use `{% raw %}` and `{% endraw %}`. But are these really necessary? I'm not using raw in my templates and everything seems to be working fine. But I didn't want to remove it without asking first, in case there's something I'm unaware of.